### PR TITLE
Make `.gitignore` nicer to VSCode users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build/
 scripts/matlab/data/
 parameters/executables/
+*.code-workspace
+.cache


### PR DESCRIPTION
Add *.vscode-workspace and *.cache to .gitignore as they are common files/folders that show up when using VSCode.